### PR TITLE
Add 404 error page

### DIFF
--- a/wp-content/themes/sejmownik/404.php
+++ b/wp-content/themes/sejmownik/404.php
@@ -6,19 +6,21 @@
 get_header();
 ?>
 
-<div>
-    <div>
-        <h1>Błąd 404</h1>
-        <h2>Strony nie znaleziono</h2>
-        <div>
-            <p>Strona, której szukasz, mogła zostać usunięta, zmieniono jej nazwę lub jest tymczasowo niedostępna.</p>
-            
-            <div>
-                <a href="<?php echo esc_url(home_url('/')); ?>">
-                    Wróć do strony głównej
+<div class="container mx-auto px-4 pb-12 pt-6">
+    <div class="bg-white rounded-lg shadow-md p-8 mx-auto text-center">
+        <div class="text-9xl font-bold text-parlament-blue mb-6">404</div>
+        <h1 class="text-3xl font-bold text-gray-800 mb-4">Strony nie znaleziono</h1>
+        <div class="text-gray-600 mb-8">
+            <p class="mb-4">Strona, której szukasz, mogła zostać usunięta, zmieniono jej nazwę lub jest tymczasowo niedostępna.</p>
+            <div class="mt-8">
+                <a href="<?php echo esc_url(home_url('/')); ?>" class="inline-flex items-center bg-parlament-red text-white py-3 px-6 rounded-md hover:bg-red-800 transition">
+                    <i class="fas fa-home mr-2"></i> Wróć do strony głównej
                 </a>
             </div>
-            
+        </div>
+        
+        <div class="mt-8 pt-8 border-t border-gray-200">
+            <p class="text-gray-500 text-sm">Możesz również spróbować przejść do <a href="<?php echo esc_url(get_post_type_archive_link('mp')); ?>" class="text-parlament-blue hover:underline">listy posłów</a> lub skorzystać z wyszukiwarki w górnej części strony.</p>
         </div>
     </div>
 </div>

--- a/wp-content/themes/sejmownik/assets/css/main.css
+++ b/wp-content/themes/sejmownik/assets/css/main.css
@@ -739,6 +739,10 @@ h1, h2, h3, h4, h5, h6 {
   width: 0.75rem;
 }
 
+.max-w-2xl {
+  max-width: 42rem;
+}
+
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
@@ -823,6 +827,11 @@ h1, h2, h3, h4, h5, h6 {
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
 }
 
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+}
+
 .bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
@@ -843,6 +852,11 @@ h1, h2, h3, h4, h5, h6 {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
 
+.bg-parlament-red {
+  --tw-bg-opacity: 1;
+  background-color: rgb(210 35 42 / var(--tw-bg-opacity, 1));
+}
+
 .object-cover {
   -o-object-fit: cover;
      object-fit: cover;
@@ -854,6 +868,10 @@ h1, h2, h3, h4, h5, h6 {
 
 .p-4 {
   padding: 1rem;
+}
+
+.p-8 {
+  padding: 2rem;
 }
 
 .px-3 {
@@ -916,6 +934,14 @@ h1, h2, h3, h4, h5, h6 {
   padding-top: 1rem;
 }
 
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pt-6 {
+  padding-top: 1.5rem;
+}
+
 .text-center {
   text-align: center;
 }
@@ -947,6 +973,11 @@ h1, h2, h3, h4, h5, h6 {
 .text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
+}
+
+.text-9xl {
+  font-size: 8rem;
+  line-height: 1;
 }
 
 .font-bold {
@@ -1001,6 +1032,11 @@ h1, h2, h3, h4, h5, h6 {
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
+.text-parlament-red {
+  --tw-text-opacity: 1;
+  color: rgb(210 35 42 / var(--tw-text-opacity, 1));
+}
+
 .opacity-80 {
   opacity: 0.8;
 }
@@ -1044,6 +1080,11 @@ h1, h2, h3, h4, h5, h6 {
 .hover\:bg-blue-800:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(30 64 175 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-red-800:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(153 27 27 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:text-parlament-gold:hover {


### PR DESCRIPTION
This pull request enhances the 404 error page design and introduces new utility classes in the CSS for improved styling and flexibility. The most significant changes include redesigning the 404 page layout with a modern look and adding CSS classes for custom colors, padding, and typography.

### 404 Page Redesign:
* Updated `404.php` to include a responsive container with a modern design, improved typography, and additional navigation options, such as a link to the list of MPs and a search suggestion. The "Back to Home" button now includes an icon and hover effects.

### New CSS Utility Classes:
* Added `.max-w-2xl` for setting a maximum width of 42rem.
* Introduced `.border-gray-200` for a light gray border color.
* Added `.bg-parlament-red` and `.hover:bg-red-800` for custom red background colors, including hover states. [[1]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R855-R859) [[2]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R1085-R1089)
* Created new padding utilities (`.p-8`, `.pb-12`, `.pt-6`) for consistent spacing. [[1]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R873-R876) [[2]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R937-R944)
* Added `.text-9xl` for large text size and `.text-parlament-red` for custom text color. [[1]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R978-R982) [[2]](diffhunk://#diff-bc09d0e6f8907d3d0a1fd5660e7658c87b92a065ba05f640244ef058bff138e7R1035-R1039)